### PR TITLE
fix build and dist instructions for phase 1 sim

### DIFF
--- a/phase1/src/main/kotlin/tech/pegasys/teku/phase1/README.md
+++ b/phase1/src/main/kotlin/tech/pegasys/teku/phase1/README.md
@@ -22,7 +22,7 @@ which has an option for Eth1 Shard.
 To create a ready to run distribution:
 
 ```shell script
-git clone -b phase1 https://github.com/PegaSysEng/teku.git
+git clone -b phase1 https://github.com/txrx-research/teku.git
 cd teku && ./gradlew :phase1:distTar :phase1:installDist
 ```
 


### PR DESCRIPTION
build instructions point to `PegaSysEng` github but branch exists on `txrx-research` github